### PR TITLE
APPS-303 + APPS-351 auto-detached subjobs + dxfuse update

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,5 +17,5 @@ img=$(echo ${resp} | awk '{print $6":"$7}' | tr -d "[" | tr -d "]")
 img=${img%:}
 
 docker tag $img $latest_tag
-docker push $latest_tag 
+docker push $latest_tag
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3.7'
- 
+
 services:
   cwic:
     build:
       context: ./docker
       dockerfile: Dockerfile
-    image: dnanexus/cwic-base:0.0.3
+    image: dnanexus/cwic-base:0.0.4

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSL get.docker.com -o get-docker.sh \
     && sh get-docker.sh
 
 RUN pip3 install --no-cache-dir \
-    dxpy
+    dxpy==v0.305.0
 
 # Install dxfuse
 RUN wget https://github.com/dnanexus/dxfuse/releases/download/v0.22.2/dxfuse-linux -P /usr/local/bin/ \
@@ -43,7 +43,7 @@ RUN wget https://github.com/dnanexus/dxfuse/releases/download/v0.22.2/dxfuse-lin
     && chmod +x /usr/local/bin/dxfuse
 
 RUN mkdir -p /project /scratch /home/dnanexus /home/cwic
- 
+
 CMD ["/bin/bash"]
 
 WORKDIR /home/cwic

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ RUN pip3 install --no-cache-dir \
     dxpy==v0.305.0
 
 # Install dxfuse
-RUN wget https://github.com/dnanexus/dxfuse/releases/download/v0.22.2/dxfuse-linux -P /usr/local/bin/ \
+RUN wget https://github.com/dnanexus/dxfuse/releases/download/v0.23.1/dxfuse-linux -P /usr/local/bin/ \
     && mv /usr/local/bin/dxfuse-linux /usr/local/bin/dxfuse \
     && chmod +x /usr/local/bin/dxfuse
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ RUN pip3 install --no-cache-dir \
     dxpy==v0.305.0
 
 # Install dxfuse
-RUN wget https://github.com/dnanexus/dxfuse/releases/download/v0.23.1/dxfuse-linux -P /usr/local/bin/ \
+RUN wget https://github.com/dnanexus/dxfuse/releases/download/v0.23.2/dxfuse-linux -P /usr/local/bin/ \
     && mv /usr/local/bin/dxfuse-linux /usr/local/bin/dxfuse \
     && chmod +x /usr/local/bin/dxfuse
 

--- a/dxapp.json
+++ b/dxapp.json
@@ -59,7 +59,7 @@
       "allProjects": "VIEW"
   },
   "details": {
-    "whatsNew": "* 0.0.6: Jobs started from Cloud workstation are started in detached mode by default. Updated version of dx-toolkit to v0.305.0. \n* 0.0.6: Add dx-find-cwic-jobs and dx-cwic-sub scripts; mount project in read only mode by default; set HOME to /home/cwic; upgrade dxfuse to v0.22.2\n* 0.0.5: Upgrade dxfuse to v0.22.1\n* 0.0.4: Load cwic when opening a tmux window; Use dnanexus/cwic-base:0.0.1 as default image; Fix prompt; Bug fixes\n* 0.0.3: Bug fixes\n* 0.0.2: Pass DNAnexus user token in credentials and use it in Docker container\n* 0.0.1: Releasing an alpha version\n"
+    "whatsNew": "* 0.1.0: Jobs started from Cloud workstation are started in detached mode by default. Updated version of dx-toolkit to v0.305.0. \n* 0.0.6: Add dx-find-cwic-jobs and dx-cwic-sub scripts; mount project in read only mode by default; set HOME to /home/cwic; upgrade dxfuse to v0.22.2\n* 0.0.5: Upgrade dxfuse to v0.22.1\n* 0.0.4: Load cwic when opening a tmux window; Use dnanexus/cwic-base:0.0.1 as default image; Fix prompt; Bug fixes\n* 0.0.3: Bug fixes\n* 0.0.2: Pass DNAnexus user token in credentials and use it in Docker container\n* 0.0.1: Releasing an alpha version\n"
   },
   "categories": ["Development", "Data Exploration"],
   "regionalOptions": {

--- a/dxapp.json
+++ b/dxapp.json
@@ -60,7 +60,7 @@
       "allProjects": "VIEW"
   },
   "details": {
-    "whatsNew": "* 0.1.0: Jobs started from Cloud workstation are started in detached mode by default. Updated version of dx-toolkit to v0.305.0. Upgraded dxfuse to v0.23.1. Updated base image to 0.0.4. \n* 0.0.6: Add dx-find-cwic-jobs and dx-cwic-sub scripts; mount project in read only mode by default; set HOME to /home/cwic; upgrade dxfuse to v0.22.2\n* 0.0.5: Upgrade dxfuse to v0.22.1\n* 0.0.4: Load cwic when opening a tmux window; Use dnanexus/cwic-base:0.0.1 as default image; Fix prompt; Bug fixes\n* 0.0.3: Bug fixes\n* 0.0.2: Pass DNAnexus user token in credentials and use it in Docker container\n* 0.0.1: Releasing an alpha version\n"
+    "whatsNew": "* 0.1.0: Jobs started from cwic are started in detached mode by default. Updated version of dx-toolkit to v0.305.0. Upgraded dxfuse to v0.23.1. Updated base image to 0.0.4. \n* 0.0.6: Add dx-find-cwic-jobs and dx-cwic-sub scripts; mount project in read only mode by default; set HOME to /home/cwic; upgrade dxfuse to v0.22.2\n* 0.0.5: Upgrade dxfuse to v0.22.1\n* 0.0.4: Load cwic when opening a tmux window; Use dnanexus/cwic-base:0.0.1 as default image; Fix prompt; Bug fixes\n* 0.0.3: Bug fixes\n* 0.0.2: Pass DNAnexus user token in credentials and use it in Docker container\n* 0.0.1: Releasing an alpha version\n"
   },
   "categories": ["Development", "Data Exploration"],
   "regionalOptions": {

--- a/dxapp.json
+++ b/dxapp.json
@@ -36,11 +36,12 @@
       "label": "Project mount options",
       "class": "string",
       "optional": true,
-      "help": "Mount options for project, set to '-w' in order to mount project with write access (experimental) otherwise read only mode will be used",
+      "help": "Mount options for project, set to '-w' or '-readWrite' in order to mount project with write access (experimental) otherwise read only mode will be used",
       "default": "-readOnly",
       "choices": [
         "-readOnly",
-        "-w"
+        "-w",
+        "-readWrite"
       ]
     }
   ],

--- a/dxapp.json
+++ b/dxapp.json
@@ -59,7 +59,7 @@
       "allProjects": "VIEW"
   },
   "details": {
-    "whatsNew": "* 0.1.0: Jobs started from Cloud workstation are started in detached mode by default. Updated version of dx-toolkit to v0.305.0. Updated base image to 0.0.4. \n* 0.0.6: Add dx-find-cwic-jobs and dx-cwic-sub scripts; mount project in read only mode by default; set HOME to /home/cwic; upgrade dxfuse to v0.22.2\n* 0.0.5: Upgrade dxfuse to v0.22.1\n* 0.0.4: Load cwic when opening a tmux window; Use dnanexus/cwic-base:0.0.1 as default image; Fix prompt; Bug fixes\n* 0.0.3: Bug fixes\n* 0.0.2: Pass DNAnexus user token in credentials and use it in Docker container\n* 0.0.1: Releasing an alpha version\n"
+    "whatsNew": "* 0.1.0: Jobs started from Cloud workstation are started in detached mode by default. Updated version of dx-toolkit to v0.305.0. Upgraded dxfuse to v0.23.1. Updated base image to 0.0.4. \n* 0.0.6: Add dx-find-cwic-jobs and dx-cwic-sub scripts; mount project in read only mode by default; set HOME to /home/cwic; upgrade dxfuse to v0.22.2\n* 0.0.5: Upgrade dxfuse to v0.22.1\n* 0.0.4: Load cwic when opening a tmux window; Use dnanexus/cwic-base:0.0.1 as default image; Fix prompt; Bug fixes\n* 0.0.3: Bug fixes\n* 0.0.2: Pass DNAnexus user token in credentials and use it in Docker container\n* 0.0.1: Releasing an alpha version\n"
   },
   "categories": ["Development", "Data Exploration"],
   "regionalOptions": {

--- a/dxapp.json
+++ b/dxapp.json
@@ -59,7 +59,7 @@
       "allProjects": "VIEW"
   },
   "details": {
-    "whatsNew": "* 0.1.0: Jobs started from Cloud workstation are started in detached mode by default. Updated version of dx-toolkit to v0.305.0. \n* 0.0.6: Add dx-find-cwic-jobs and dx-cwic-sub scripts; mount project in read only mode by default; set HOME to /home/cwic; upgrade dxfuse to v0.22.2\n* 0.0.5: Upgrade dxfuse to v0.22.1\n* 0.0.4: Load cwic when opening a tmux window; Use dnanexus/cwic-base:0.0.1 as default image; Fix prompt; Bug fixes\n* 0.0.3: Bug fixes\n* 0.0.2: Pass DNAnexus user token in credentials and use it in Docker container\n* 0.0.1: Releasing an alpha version\n"
+    "whatsNew": "* 0.1.0: Jobs started from Cloud workstation are started in detached mode by default. Updated version of dx-toolkit to v0.305.0. Updated base image to 0.0.4. \n* 0.0.6: Add dx-find-cwic-jobs and dx-cwic-sub scripts; mount project in read only mode by default; set HOME to /home/cwic; upgrade dxfuse to v0.22.2\n* 0.0.5: Upgrade dxfuse to v0.22.1\n* 0.0.4: Load cwic when opening a tmux window; Use dnanexus/cwic-base:0.0.1 as default image; Fix prompt; Bug fixes\n* 0.0.3: Bug fixes\n* 0.0.2: Pass DNAnexus user token in credentials and use it in Docker container\n* 0.0.1: Releasing an alpha version\n"
   },
   "categories": ["Development", "Data Exploration"],
   "regionalOptions": {

--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
   "title": "CWIC - cloud workstation in container",
   "summary": "Develop and scale in a portable interactive cloud environment",
   "dxapi": "1.0.0",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "billTo": "org-dnanexus_apps",
   "openSource": true,
   "inputSpec": [
@@ -59,7 +59,7 @@
       "allProjects": "VIEW"
   },
   "details": {
-    "whatsNew": "* 0.0.6: Add dx-find-cwic-jobs and dx-cwic-sub scripts; mount project in read only mode by default; set HOME to /home/cwic; upgrade dxfuse to v0.22.2\n* 0.0.5: Upgrade dxfuse to v0.22.1\n* 0.0.4: Load cwic when opening a tmux window; Use dnanexus/cwic-base:0.0.1 as default image; Fix prompt; Bug fixes\n* 0.0.3: Bug fixes\n* 0.0.2: Pass DNAnexus user token in credentials and use it in Docker container\n* 0.0.1: Releasing an alpha version\n"
+    "whatsNew": "* 0.0.6: Jobs started from Cloud workstation are started in detached mode by default. Updated version of dx-toolkit to v0.305.0. \n* 0.0.6: Add dx-find-cwic-jobs and dx-cwic-sub scripts; mount project in read only mode by default; set HOME to /home/cwic; upgrade dxfuse to v0.22.2\n* 0.0.5: Upgrade dxfuse to v0.22.1\n* 0.0.4: Load cwic when opening a tmux window; Use dnanexus/cwic-base:0.0.1 as default image; Fix prompt; Bug fixes\n* 0.0.3: Bug fixes\n* 0.0.2: Pass DNAnexus user token in credentials and use it in Docker container\n* 0.0.1: Releasing an alpha version\n"
   },
   "categories": ["Development", "Data Exploration"],
   "regionalOptions": {

--- a/resources/usr/local/bin/dx-cwic-sub
+++ b/resources/usr/local/bin/dx-cwic-sub
@@ -43,11 +43,11 @@ if [[ "$LAST_ARG" == --* ]]; then
 fi
 
 if [ $ABLE_TO_RUN_DETACH = 0 ]; then
-    echo -e "Please update the version of dx to run jobs in detached mode. To update dx use 'pip install dxpy --upgrade'"
+    echo -e "Please update the version of dx to be able to run jobs in detached mode. To update dx use 'pip install dxpy --upgrade'"
 fi
 
 # Detached jobs do not require DNAnexus token if current dx-toolkit version supports detached jobs.
-if [[ $DX_DETACH_RUN != 1 || $ABLE_TO_RUN_DETACH = 1 ]] ; then
+if [[ $DX_DETACH_RUN != 1 || $ABLE_TO_RUN_DETACH = 0 ]] ; then
     USER=$(dx whoami 2>/dev/null) || true
     if [[ $(dx describe user-"${USER}" --json 2>/dev/null | jq -r ".billTo") == "null" ]] || [[ -z "${USER}" ]]; then
         echo -e "User is not logged in. Retrieving DNAnexus auth token from the credentials file..."

--- a/resources/usr/local/bin/dx-cwic-sub
+++ b/resources/usr/local/bin/dx-cwic-sub
@@ -13,6 +13,13 @@ JOB_INPUT_FILE="${DNANEXUS_HOME}/job_input.json"
 JOB_INFO_FILE="${DNANEXUS_HOME}/dnanexus-job.json"
 ALL_BUT_LAST_ARG=${*:1:$#-1}
 LAST_ARG=${*: -1}
+DX_VERSION=$(dx --version | sed 's/.* //')
+FIRST_DETACHED_VERSION="v0.305.0"
+if [[ ($FIRST_DETACHED_VERSION != $DX_VERSION && $FIRST_DETACHED_VERSION = "`echo -e "$FIRST_DETACHED_VERSION\n$DX_VERSION" | sort -V | head -n1`") ]]; then
+    ABLE_TO_RUN_DETACH=1
+else
+    ABLE_TO_RUN_DETACH=0
+fi
 
 if [[ $1 == "--help" || $1 == "-h" ]]; then
     echo -e "Usage: $0"
@@ -35,20 +42,27 @@ if [[ "$LAST_ARG" == --* ]]; then
     exit
 fi
 
-USER=$(dx whoami 2>/dev/null) || true
-if [[ $(dx describe user-"${USER}" --json 2>/dev/null | jq -r ".billTo") == "null" ]] || [[ -z "${USER}" ]]; then
-    echo -e "User is not logged in. Retrieving DNAnexus auth token from the credentials file..."
-    if [[ -f "$CREDENTIALS_FILE_PATH" ]]; then
-        DNANEXUS_TOKEN=$(jq -r ".dnanexus.token" <"${CREDENTIALS_FILE_PATH}")
-    else
-        echo -e "The credentials file does not exist. Please log in and try again. Exiting..."
-        exit 1
+if [ $ABLE_TO_RUN_DETACH = 0 ]; then
+    echo -e "Please update the version of dx to run jobs in detached mode. To update dx use 'pip install dxpy --upgrade'"
+fi
+
+# Detached jobs do not require DNAnexus token if current dx-toolkit version supports detached jobs.
+if [[ $DX_DETACH_RUN != 1 || $ABLE_TO_RUN_DETACH == 1 ]] ; then
+    USER=$(dx whoami 2>/dev/null) || true
+    if [[ $(dx describe user-"${USER}" --json 2>/dev/null | jq -r ".billTo") == "null" ]] || [[ -z "${USER}" ]]; then
+        echo -e "User is not logged in. Retrieving DNAnexus auth token from the credentials file..."
+        if [[ -f "$CREDENTIALS_FILE_PATH" ]]; then
+            DNANEXUS_TOKEN=$(jq -r ".dnanexus.token" <"${CREDENTIALS_FILE_PATH}")
+        else
+            echo -e "The credentials file does not exist. Please log in and try again. Exiting..."
+            exit 1
+        fi
+        if [[ "${DNANEXUS_TOKEN}" == "null" ]] || [[ -z "${DNANEXUS_TOKEN}" ]]; then
+            echo -e "DNAnexus token is not set in the credentials file. Please provide DNAnexus token or log in. Exiting..."
+            exit 1
+        fi
+        dx login --noprojects --token "$DNANEXUS_TOKEN"
     fi
-    if [[ "${DNANEXUS_TOKEN}" == "null" ]] || [[ -z "${DNANEXUS_TOKEN}" ]]; then
-        echo -e "DNAnexus token is not set in the credentials file. Please provide DNAnexus token or log in. Exiting..."
-        exit 1
-    fi
-    dx login --noprojects --token "$DNANEXUS_TOKEN"
 fi
 
 opts=()

--- a/resources/usr/local/bin/dx-cwic-sub
+++ b/resources/usr/local/bin/dx-cwic-sub
@@ -15,7 +15,7 @@ ALL_BUT_LAST_ARG=${*:1:$#-1}
 LAST_ARG=${*: -1}
 DX_VERSION=$(dx --version | sed 's/.* //')
 FIRST_DETACHED_VERSION="v0.305.0"
-if [[ ($FIRST_DETACHED_VERSION != $DX_VERSION && $FIRST_DETACHED_VERSION = "`echo -e "$FIRST_DETACHED_VERSION\n$DX_VERSION" | sort -V | head -n1`") ]]; then
+if [[ ($FIRST_DETACHED_VERSION != $DX_VERSION && $DX_VERSION = "`echo -e "$DX_VERSION\n$FIRST_DETACHED_VERSION" | sort -V | head -n1`") ]]; then
     ABLE_TO_RUN_DETACH=0
 else
     ABLE_TO_RUN_DETACH=1

--- a/resources/usr/local/bin/dx-cwic-sub
+++ b/resources/usr/local/bin/dx-cwic-sub
@@ -16,9 +16,9 @@ LAST_ARG=${*: -1}
 DX_VERSION=$(dx --version | sed 's/.* //')
 FIRST_DETACHED_VERSION="v0.305.0"
 if [[ ($FIRST_DETACHED_VERSION != $DX_VERSION && $FIRST_DETACHED_VERSION = "`echo -e "$FIRST_DETACHED_VERSION\n$DX_VERSION" | sort -V | head -n1`") ]]; then
-    ABLE_TO_RUN_DETACH=1
-else
     ABLE_TO_RUN_DETACH=0
+else
+    ABLE_TO_RUN_DETACH=1
 fi
 
 if [[ $1 == "--help" || $1 == "-h" ]]; then
@@ -43,7 +43,7 @@ if [[ "$LAST_ARG" == --* ]]; then
 fi
 
 if [ $ABLE_TO_RUN_DETACH = 0 ]; then
-    echo -e "Please update the version of dx to be able to run jobs in detached mode. To update dx use 'pip install dxpy --upgrade'"
+    echo -e "Please update the version of dxpy in your Docker image to be able to run jobs in detached mode. To update dx use 'pip3 install dxpy --upgrade'"
 fi
 
 # Detached jobs do not require DNAnexus token if current dx-toolkit version supports detached jobs.

--- a/resources/usr/local/bin/dx-cwic-sub
+++ b/resources/usr/local/bin/dx-cwic-sub
@@ -8,6 +8,7 @@ if [ $# -eq 0 ]; then
 fi
 
 DNANEXUS_HOME=/home/dnanexus
+ENVIRONMENT_FILE="${DNANEXUS_HOME}/environment"
 CREDENTIALS_FILE_PATH="${DNANEXUS_HOME}/credentials"
 JOB_INPUT_FILE="${DNANEXUS_HOME}/job_input.json"
 JOB_INFO_FILE="${DNANEXUS_HOME}/dnanexus-job.json"
@@ -25,6 +26,7 @@ if [[ $1 == "--help" || $1 == "-h" ]]; then
     echo -e "Usage: $0"
     echo -e "Launches cwic app in batch from inside an interactive cwic session."
     echo -e "Uses user's auth token if logged in, if not, then uses auth token from DNAnexus config or the credentials file."
+    echo -e "Auth token is not required while running in detached mode. To run in detached mode run 'export DX_RUN_DETACH=1'. This value should be default in cwic."
     echo -e "The last argument is expected to be the command run by cwic. It can be preceded by CLI arguments accepted by dx run."
     echo -e "For more details please check 'dx run -h'."
     echo -e "Examples:"
@@ -46,21 +48,22 @@ if [ $ABLE_TO_RUN_DETACH = 0 ]; then
     echo -e "Please update the version of dxpy in your Docker image to be able to run jobs in detached mode. To update dx use 'pip3 install dxpy --upgrade'"
 fi
 
-# Detached jobs do not require DNAnexus token if current dx-toolkit version supports detached jobs.
-if [[ $DX_RUN_DETACH != 1 || $ABLE_TO_RUN_DETACH = 0 ]] ; then
-    USER=$(dx whoami 2>/dev/null) || true
-    if [[ $(dx describe user-"${USER}" --json 2>/dev/null | jq -r ".billTo") == "null" ]] || [[ -z "${USER}" ]]; then
-        echo -e "User is not logged in. Retrieving DNAnexus auth token from the credentials file..."
-        if [[ -f "$CREDENTIALS_FILE_PATH" ]]; then
-            DNANEXUS_TOKEN=$(jq -r ".dnanexus.token" <"${CREDENTIALS_FILE_PATH}")
+USER=$(dx whoami 2>/dev/null) || true
+if [[ $(dx describe user-"${USER}" --json 2>/dev/null | jq -r ".billTo") == "null" ]] || [[ -z "${USER}" ]]; then
+    echo -e "User is not logged in. Retrieving DNAnexus auth token from the credentials file..."
+    if [[ -f "$CREDENTIALS_FILE_PATH" ]]; then
+        DNANEXUS_TOKEN=$(jq -r ".dnanexus.token" <"${CREDENTIALS_FILE_PATH}")
+    fi
+
+    if [[ "${DNANEXUS_TOKEN}" == "null" ]] || [[ -z "${DNANEXUS_TOKEN}" ]]; then
+        if [[ $DX_RUN_DETACH != 1 || $ABLE_TO_RUN_DETACH = 0 ]]; then
+            echo -e "DNAnexus token was not found. Please provide DNAnexus token, log in or run 'export DX_RUN_DETACH=1' to run dx-cwic-sub in detached mode. Exiting..."
+            exit 1
         else
-            echo -e "The credentials file does not exist. Please log in and try again. Exiting..."
-            exit 1
+            echo -e "DNAnexus token was not found. Sourcing environment file (${ENVIRONMENT_FILE}) in order to run job in detached mode."
+            source $ENVIRONMENT_FILE
         fi
-        if [[ "${DNANEXUS_TOKEN}" == "null" ]] || [[ -z "${DNANEXUS_TOKEN}" ]]; then
-            echo -e "DNAnexus token is not set in the credentials file. Please provide DNAnexus token or log in. Exiting..."
-            exit 1
-        fi
+    else
         dx login --noprojects --token "$DNANEXUS_TOKEN"
     fi
 fi

--- a/resources/usr/local/bin/dx-cwic-sub
+++ b/resources/usr/local/bin/dx-cwic-sub
@@ -47,7 +47,7 @@ if [ $ABLE_TO_RUN_DETACH = 0 ]; then
 fi
 
 # Detached jobs do not require DNAnexus token if current dx-toolkit version supports detached jobs.
-if [[ $DX_DETACH_RUN != 1 || $ABLE_TO_RUN_DETACH == 1 ]] ; then
+if [[ $DX_DETACH_RUN != 1 || $ABLE_TO_RUN_DETACH = 1 ]] ; then
     USER=$(dx whoami 2>/dev/null) || true
     if [[ $(dx describe user-"${USER}" --json 2>/dev/null | jq -r ".billTo") == "null" ]] || [[ -z "${USER}" ]]; then
         echo -e "User is not logged in. Retrieving DNAnexus auth token from the credentials file..."

--- a/resources/usr/local/bin/dx-cwic-sub
+++ b/resources/usr/local/bin/dx-cwic-sub
@@ -47,7 +47,7 @@ if [ $ABLE_TO_RUN_DETACH = 0 ]; then
 fi
 
 # Detached jobs do not require DNAnexus token if current dx-toolkit version supports detached jobs.
-if [[ $DX_DETACH_RUN != 1 || $ABLE_TO_RUN_DETACH = 0 ]] ; then
+if [[ $DX_RUN_DETACH != 1 || $ABLE_TO_RUN_DETACH = 0 ]] ; then
     USER=$(dx whoami 2>/dev/null) || true
     if [[ $(dx describe user-"${USER}" --json 2>/dev/null | jq -r ".billTo") == "null" ]] || [[ -z "${USER}" ]]; then
         echo -e "User is not logged in. Retrieving DNAnexus auth token from the credentials file..."

--- a/resources/usr/local/bin/dx-start-cwic
+++ b/resources/usr/local/bin/dx-start-cwic
@@ -5,6 +5,7 @@ set -e
 DNANEXUS_HOME="/home/dnanexus"
 JOB_INPUT_FILE="${DNANEXUS_HOME}/job_input.json"
 ENV="${DNANEXUS_HOME}/environment"
+export DX_RUN_DETACH=1
 
 # if user provided their authentication token in the input, use it
 # otherwise source environment to make use of the job's token

--- a/resources/usr/local/bin/dxfuse-mount
+++ b/resources/usr/local/bin/dxfuse-mount
@@ -5,7 +5,7 @@ JOB_INPUT_FILE="${DNANEXUS_HOME}/job_input.json"
 
 READ_ONLY="-readOnly"
 if [[ -f "$JOB_INPUT_FILE" ]] && [[ "$(jq -r ".project_mount_options" <"${JOB_INPUT_FILE}")" != "-readOnly" ]]; then
-    READ_ONLY=""
+    READ_ONLY="-readWrite"
 fi
 
 if dxfuse $READ_ONLY $@; then

--- a/src/code.sh
+++ b/src/code.sh
@@ -14,9 +14,6 @@ main() {
         echo "Will start interactive Docker container"
         INTERACTIVE=1
 
-        # interactive apps should run sub-jobs detached automatically.
-        export DX_RUN_DETACH=1
-
         allow_ssh=$(jq .allowSSH /home/dnanexus/dnanexus-job.json)
         if [[ -z "$allow_ssh" || "$allow_ssh" == null ]]; then
             echo "ERROR: job not run with the ssh flag on and command is not provided."
@@ -126,7 +123,7 @@ main() {
         --entrypoint /usr/local/bin/dx-start-cwic
         --workdir /home/cwic
         -e HOME=/home/cwic
-        -e DX_RUN_DETACH
+        -e DX_RUN_DETACH=$INTERACTIVE
         --name cwic"
 
     mark-section "starting Docker container"

--- a/src/code.sh
+++ b/src/code.sh
@@ -14,6 +14,9 @@ main() {
         echo "Will start interactive Docker container"
         INTERACTIVE=1
 
+        # interactive apps should run sub-jobs detached automatically.
+        export DX_RUN_DETACH=1
+
         allow_ssh=$(jq .allowSSH /home/dnanexus/dnanexus-job.json)
         if [[ -z "$allow_ssh" || "$allow_ssh" == null ]]; then
             echo "ERROR: job not run with the ssh flag on and command is not provided."
@@ -123,6 +126,7 @@ main() {
         --entrypoint /usr/local/bin/dx-start-cwic
         --workdir /home/cwic
         -e HOME=/home/cwic
+        -e DX_RUN_DETACH
         --name cwic"
 
     mark-section "starting Docker container"

--- a/src/code.sh
+++ b/src/code.sh
@@ -6,7 +6,7 @@ main() {
     echo "Value of cmd: '$cmd'"
     echo "Value of credentials: '$credentials'"
 
-    DXBASEIMG=dnanexus/cwic-base:0.0.3
+    DXBASEIMG=dnanexus/cwic-base:0.0.4
 
     mark-section "checking if cwic will be run interactively or in non-interactive batch mode"
 
@@ -123,7 +123,7 @@ main() {
         --entrypoint /usr/local/bin/dx-start-cwic
         --workdir /home/cwic
         -e HOME=/home/cwic
-        -e DX_RUN_DETACH=$INTERACTIVE
+        -e DX_RUN_DETACH=1
         --name cwic"
 
     mark-section "starting Docker container"


### PR DESCRIPTION
Subjobs in cwic are started as detached if $cmd is not passed as argument to cwic (more precisely, DX_RUN_DETACH is set to $INTERACTIVE from cwic).

This means that if used starts cwic with $cmd AND with --ssh flag, subjobs will not run as detached. Is this correct?
@emiloslavsky 

Also note that DX_RUN_DETACH is set only in docker, not on the worker - if user exits from docker, jobs will not be detached